### PR TITLE
feature: 비밀번호 재설정을 위한 이메일 인증 및 비밀번호 재설정 기능 구현

### DIFF
--- a/src/main/java/com/mozi/domain/user/controller/UserController.java
+++ b/src/main/java/com/mozi/domain/user/controller/UserController.java
@@ -59,7 +59,7 @@ public class UserController implements UserSpecification{
 
     @PostMapping("/password-reset/send-email")
     public ResponseEntity<ApiResponse<Void>> sendPasswordResetEmail(@Valid @RequestBody EmailVerificationRequest request) {
-        // TODO: 비밀번호 재설정 이메일 발송 로직 구현
+        userService.sendPasswordResetEmail(request);
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/mozi/domain/user/controller/UserController.java
+++ b/src/main/java/com/mozi/domain/user/controller/UserController.java
@@ -65,7 +65,7 @@ public class UserController implements UserSpecification{
 
     @PostMapping("/password-reset/confirm")
     public ResponseEntity<ApiResponse<Void>> resetPassword(@RequestBody @Valid PasswordResetRequest request) {
-        // TODO: 비밀번호 재설정 로직 구현
+        userService.resetPassword(request);
         return ResponseEntity.ok(ApiResponse.success());
     }
 

--- a/src/main/java/com/mozi/domain/user/controller/dto/request/PasswordResetRequest.java
+++ b/src/main/java/com/mozi/domain/user/controller/dto/request/PasswordResetRequest.java
@@ -13,6 +13,10 @@ public class PasswordResetRequest {
     @Email
     private String email;
 
+    @Schema(description = "이메일로 발송된 인증 코드", example = "123456")
+    @NotBlank
+    private String verificationCode;
+
     @Schema(description = "새로운 비밀번호", example = "newPassword1!")
     @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#&()–[{}]:;',?/*~$^+=<>]).{8,}$",
             message = "비밀번호는 숫자, 영문, 특수문자를 혼합하여 8자 이상이어야 합니다.")

--- a/src/main/java/com/mozi/domain/user/entity/User.java
+++ b/src/main/java/com/mozi/domain/user/entity/User.java
@@ -46,6 +46,10 @@ public class User extends BaseEntity {
         this.refreshToken = null;
     }
 
+    public void updatePassword(String encode) {
+        this.password = encode;
+    }
+
     protected User() {}
 
     @Builder

--- a/src/main/java/com/mozi/domain/user/service/UserService.java
+++ b/src/main/java/com/mozi/domain/user/service/UserService.java
@@ -52,12 +52,12 @@ public class UserService {
     }
 
     public void sendVerificationEmail(EmailVerificationRequest request) {
-
         if (userRepository.existsByEmailAndActivatedTrue(request.getEmail())) {
             throw new BusinessException(ErrorCode.CONFLICT_REGISTER);
         }
 
-        mailSendService.sendEmail(request.getEmail());
+        String title = "Mozi 회원가입 인증 이메일 입니다.";
+        mailSendService.sendAuthEmail(request.getEmail(), title, "mail/verificationCode");
     }
 
     public void verifyEmail(EmailVerificationConfirmRequest request) {
@@ -71,12 +71,12 @@ public class UserService {
     }
 
     public void sendPasswordResetEmail(EmailVerificationRequest request) {
-
         if (!userRepository.existsByEmailAndActivatedTrue(request.getEmail())) {
             throw new BusinessException(ErrorCode.NOT_FOUND_MEMBER);
         }
 
-        mailSendService.sendEmail(request.getEmail());
+        String title = "Mozi 비밀번호 재설정 인증 이메일 입니다.";
+        mailSendService.sendAuthEmail(request.getEmail(), title, "mail/passwordResetCode");
     }
 
     @Transactional

--- a/src/main/java/com/mozi/domain/user/service/UserService.java
+++ b/src/main/java/com/mozi/domain/user/service/UserService.java
@@ -70,6 +70,15 @@ public class UserService {
         redisService.deleteValues(AUTH_CODE_PREFIX + request.getEmail());
     }
 
+    public void sendPasswordResetEmail(EmailVerificationRequest request) {
+
+        if (!userRepository.existsByEmailAndActivatedTrue(request.getEmail())) {
+            throw new BusinessException(ErrorCode.NOT_FOUND_MEMBER);
+        }
+
+        mailSendService.sendEmail(request.getEmail());
+    }
+
     @Transactional
     public LoginResponse login(LoginRequest request) {
         User user = userRepository.findByEmailAndActivatedTrue(request.getEmail())

--- a/src/main/java/com/mozi/domain/user/service/UserService.java
+++ b/src/main/java/com/mozi/domain/user/service/UserService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 @Service
 public class UserService {
 
@@ -51,6 +50,7 @@ public class UserService {
         return savedUser.getId();
     }
 
+    @Transactional
     public void sendVerificationEmail(EmailVerificationRequest request) {
         if (userRepository.existsByEmailAndActivatedTrue(request.getEmail())) {
             throw new BusinessException(ErrorCode.CONFLICT_REGISTER);
@@ -60,6 +60,7 @@ public class UserService {
         mailSendService.sendAuthEmail(request.getEmail(), title, "mail/verificationCode");
     }
 
+    @Transactional
     public void verifyEmail(EmailVerificationConfirmRequest request) {
         String redisAuthCode = redisService.getValues(AUTH_CODE_PREFIX + request.getEmail());
 
@@ -70,6 +71,7 @@ public class UserService {
         redisService.deleteValues(AUTH_CODE_PREFIX + request.getEmail());
     }
 
+    @Transactional
     public void sendPasswordResetEmail(EmailVerificationRequest request) {
         if (!userRepository.existsByEmailAndActivatedTrue(request.getEmail())) {
             throw new BusinessException(ErrorCode.NOT_FOUND_MEMBER);
@@ -115,6 +117,7 @@ public class UserService {
         return jwtUtil.createAccessToken(email);
     }
 
+    @Transactional(readOnly = true)
     public NicknameExistsResponse checkNicknameDuplicate(String nickname) {
         boolean exists = userRepository.existsByNicknameAndActivatedTrue(nickname);
         return NicknameExistsResponse.of(exists);

--- a/src/main/java/com/mozi/global/redis/RedisService.java
+++ b/src/main/java/com/mozi/global/redis/RedisService.java
@@ -16,8 +16,8 @@ public class RedisService {
         redisTemplate.opsForValue().set(key, value);
     }
 
-    public void setValuesWithTimeout(String key, String value, long timeout) {
-        redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
+    public void setValuesWithTimeout(String key, String value, long timeoutSeconds) {
+        redisTemplate.opsForValue().set(key, value, timeoutSeconds, TimeUnit.SECONDS);
     }
 
     public String getValues(String key) {

--- a/src/main/resources/templates/mail/passwordResetCode.html
+++ b/src/main/resources/templates/mail/passwordResetCode.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body style="font-family: Arial, sans-serif;">
+<div style="max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #e0e0e0;">
+    <h2 style="color: #333;">Mozi 비밀번호 재설정 인증 코드 안내</h2>
+    <p><strong>Mozi</strong> 계정의 비밀번호 재설정을 요청해주셔서 감사합니다.</p>
+    <p>아래 인증 코드를 비밀번호 재설정 창에 입력해주세요.</p>
+    <div style="margin: 20px 0; padding: 20px; background-color: #f5f5f5; text-align: center; font-size: 24px; font-weight: bold;"
+         th:text="${authCode}">
+    </div>
+    <p style="font-size: 12px; color: #888;">* 이 인증 코드는 5분간 유효합니다.</p>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈 <!-- 이슈 번호를 적어주세요 -->
Closed #43 
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
비밀 번호를 잊어버렸을 시 이메일 인증을 통해 본인 인증을 하고,
이후 새로운 비밀번호로 재설정 합니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 기존에 가입했던 이메일로 진행합니다.
- 인증코드 유효시간은 5분입니다.
- 비밀번호 재설정 합니다.
<img width="705" height="351" alt="image" src="https://github.com/user-attachments/assets/444af1f4-6ccd-427d-b5a9-66a9ae2d0898" />
